### PR TITLE
Fix README VM commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ lume create my-vm --os macos --cpu 4 --memory 8GB --disk-size 50GB
 lume run macos-sequoia-cua:latest
 
 # Stop a VM
-lume stop macos-sequoia-cua_latest
+lume stop macos-sequoia-cua:latest
 
 # Delete a VM
-lume delete macos-sequoia-cua_latest
+lume delete macos-sequoia-cua:latest
 ```
 
 ### Lumier CLI Reference


### PR DESCRIPTION
## Summary
- correct stop and delete commands for macOS VM in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68824764e14c83268b8ef8c0ee921f70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples in the README to use the correct VM identifier format with a colon (e.g., `macos-sequoia-cua:latest`) for stopping and deleting VMs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->