### PR TITLE
Add VM info parser and tests

### DIFF
--- a/libs/python/computer/computer/utils.py
+++ b/libs/python/computer/computer/utils.py
@@ -98,4 +98,7 @@ def get_image_size(image_bytes: bytes) -> Tuple[int, int]:
 def parse_vm_info(vm_info: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Parse VM info from pylume response."""
     if not vm_info:
-        return None 
+        return None
+
+    fields = ["ip_address", "name", "provider", "status"]
+    return {field: vm_info.get(field) for field in fields}

--- a/libs/python/computer/tests/test_utils.py
+++ b/libs/python/computer/tests/test_utils.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import importlib.util
+import pytest
+
+# Load utils module directly without importing the whole package
+UTILS_PATH = Path(__file__).resolve().parents[1] / "computer" / "utils.py"
+spec = importlib.util.spec_from_file_location("utils", UTILS_PATH)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+parse_vm_info = utils.parse_vm_info
+
+
+def test_parse_vm_info_valid():
+    vm_info = {
+        "ip_address": "1.2.3.4",
+        "name": "test-vm",
+        "provider": "lume",
+        "status": "running",
+        "extra": "ignore"
+    }
+    assert parse_vm_info(vm_info) == {
+        "ip_address": "1.2.3.4",
+        "name": "test-vm",
+        "provider": "lume",
+        "status": "running",
+    }
+
+
+def test_parse_vm_info_empty():
+    assert parse_vm_info(None) is None
+    assert parse_vm_info({}) is None
+
+
+


### PR DESCRIPTION
## Summary
- extend `parse_vm_info` to return a subset of fields
- add tests for parsing helper

## Testing
- `pytest -q libs/python/computer/tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68824e45f8488326b67c32ff50ff3a94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the extraction of VM information to ensure only relevant fields ("ip_address", "name", "provider", "status") are included in the output.

* **Tests**
  * Added tests to verify correct extraction of VM information and handling of empty input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->