### PR TITLE
Skip tests if CUA env vars missing

### DIFF
--- a/tests/files.py
+++ b/tests/files.py
@@ -21,6 +21,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "CUA_API_KEY and CUA_CONTAINER_NAME must be set to run these tests",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):

--- a/tests/shell_bash.py
+++ b/tests/shell_bash.py
@@ -21,6 +21,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "CUA_API_KEY and CUA_CONTAINER_NAME must be set to run these tests",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):

--- a/tests/shell_cmd.py
+++ b/tests/shell_cmd.py
@@ -21,6 +21,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "CUA_API_KEY and CUA_CONTAINER_NAME must be set to run these tests",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):

--- a/tests/venv.py
+++ b/tests/venv.py
@@ -22,6 +22,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "CUA_API_KEY and CUA_CONTAINER_NAME must be set to run these tests",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):

--- a/tests/watchdog.py
+++ b/tests/watchdog.py
@@ -22,6 +22,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "CUA_API_KEY and CUA_CONTAINER_NAME must be set to run these tests",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):


### PR DESCRIPTION
## Summary
- skip tests in `tests/*.py` if `CUA_API_KEY` or `CUA_CONTAINER_NAME` are not defined

## Testing
- `pytest tests/shell_cmd.py -q`
- `pytest tests/shell_bash.py -q`
- `pytest tests/files.py -q`
- `pytest tests/venv.py -q`
- `pytest tests/watchdog.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68824e4855cc832689bfc5f0d641cdf6