### PR TITLE
Add env check skips to integration tests

### DIFF
--- a/tests/files.py
+++ b/tests/files.py
@@ -21,6 +21,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "Missing CUA_API_KEY or CUA_CONTAINER_NAME environment variables",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):

--- a/tests/shell_bash.py
+++ b/tests/shell_bash.py
@@ -21,6 +21,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "Missing CUA_API_KEY or CUA_CONTAINER_NAME environment variables",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):

--- a/tests/shell_cmd.py
+++ b/tests/shell_cmd.py
@@ -21,6 +21,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "Missing CUA_API_KEY or CUA_CONTAINER_NAME environment variables",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):

--- a/tests/venv.py
+++ b/tests/venv.py
@@ -22,6 +22,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "Missing CUA_API_KEY or CUA_CONTAINER_NAME environment variables",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):

--- a/tests/watchdog.py
+++ b/tests/watchdog.py
@@ -22,6 +22,13 @@ from dotenv import load_dotenv
 
 load_dotenv(env_file)
 
+# Skip tests if required environment variables are missing
+if not os.getenv("CUA_API_KEY") or not os.getenv("CUA_CONTAINER_NAME"):
+    pytest.skip(
+        "Missing CUA_API_KEY or CUA_CONTAINER_NAME environment variables",
+        allow_module_level=True,
+    )
+
 # Add paths to sys.path if needed
 pythonpath = os.environ.get("PYTHONPATH", "")
 for path in pythonpath.split(":"):


### PR DESCRIPTION
## Summary
- skip tests under `tests/` when CUA credentials are missing

## Testing
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68824e551b28832695c9270f43ac6bf9