### PR TITLE
Improve parse_vm_info utility

### DIFF
--- a/libs/python/computer/computer/utils.py
+++ b/libs/python/computer/computer/utils.py
@@ -98,4 +98,10 @@ def get_image_size(image_bytes: bytes) -> Tuple[int, int]:
 def parse_vm_info(vm_info: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Parse VM info from pylume response."""
     if not vm_info:
-        return None 
+        return None
+
+    # Only expose a subset of keys that are relevant to the caller
+    fields = ["ip_address", "name", "provider", "status"]
+    parsed = {field: vm_info.get(field) for field in fields if field in vm_info}
+
+    return parsed

--- a/libs/python/computer/tests/test_utils.py
+++ b/libs/python/computer/tests/test_utils.py
@@ -1,0 +1,30 @@
+import pytest
+import importlib.util
+from pathlib import Path
+
+UTILS_PATH = Path(__file__).resolve().parents[1] / "computer" / "utils.py"
+spec = importlib.util.spec_from_file_location("utils", UTILS_PATH)
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+parse_vm_info = utils.parse_vm_info
+
+
+def test_parse_vm_info_valid():
+    vm_info = {
+        "ip_address": "192.168.1.1",
+        "name": "test-vm",
+        "provider": "lume",
+        "status": "running",
+        "extra": "ignore"
+    }
+    expected = {
+        "ip_address": "192.168.1.1",
+        "name": "test-vm",
+        "provider": "lume",
+        "status": "running",
+    }
+    assert parse_vm_info(vm_info) == expected
+
+
+def test_parse_vm_info_empty():
+    assert parse_vm_info({}) is None


### PR DESCRIPTION
## Summary
- implement vm info parsing in `utils.parse_vm_info`
- add unit tests for parsing util

## Testing
- `pytest libs/python/computer/tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882528ee1d483269d1c5789c649918c