### PR TITLE
Add Azure OpenAI provider

### DIFF
--- a/libs/python/agent/agent/core/provider_config.py
+++ b/libs/python/agent/agent/core/provider_config.py
@@ -9,6 +9,7 @@ DEFAULT_MODELS = {
     LLMProvider.OLLAMA: "gemma3:4b-it-q4_K_M",
     LLMProvider.OAICOMPAT: "Qwen2.5-VL-7B-Instruct",
     LLMProvider.MLXVLM: "mlx-community/UI-TARS-1.5-7B-4bit",
+    LLMProvider.AZURE_OPENAI: "gpt-4o",
 }
 
 # Map providers to their environment variable names
@@ -18,4 +19,5 @@ ENV_VARS = {
     LLMProvider.OLLAMA: "none",
     LLMProvider.OAICOMPAT: "none",  # OpenAI-compatible API typically doesn't require an API key
     LLMProvider.MLXVLM: "none",  # MLX VLM typically doesn't require an API key
+    LLMProvider.AZURE_OPENAI: "AZURE_OPENAI_API_KEY",
 }

--- a/libs/python/agent/agent/core/types.py
+++ b/libs/python/agent/agent/core/types.py
@@ -1,8 +1,9 @@
 """Core type definitions."""
 
-from typing import Any, Dict, List, Optional, TypedDict, Union
-from enum import StrEnum
+import os
 from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 
 class AgentLoop(StrEnum):
@@ -21,9 +22,10 @@ class LLMProvider(StrEnum):
 
     ANTHROPIC = "anthropic"
     OPENAI = "openai"
+    AZURE_OPENAI = "azure_openai"
     OLLAMA = "ollama"
     OAICOMPAT = "oaicompat"
-    MLXVLM= "mlxvlm"
+    MLXVLM = "mlxvlm"
 
 
 @dataclass
@@ -42,13 +44,16 @@ class LLM:
             self.name = DEFAULT_MODELS.get(self.provider)
 
         # Set default provider URL if none provided
-        if self.provider_base_url is None and self.provider == LLMProvider.OAICOMPAT:
-            # Default for vLLM
-            self.provider_base_url = "http://localhost:8000/v1"
-            # Common alternatives:
-            # - LM Studio: "http://localhost:1234/v1"
-            # - LocalAI: "http://localhost:8080/v1"
-            # - Ollama with OpenAI compatible API: "http://localhost:11434/v1"
+        if self.provider_base_url is None:
+            if self.provider == LLMProvider.OAICOMPAT:
+                # Default for vLLM
+                self.provider_base_url = "http://localhost:8000/v1"
+                # Common alternatives:
+                # - LM Studio: "http://localhost:1234/v1"
+                # - LocalAI: "http://localhost:8080/v1"
+                # - Ollama with OpenAI compatible API: "http://localhost:11434/v1"
+            elif self.provider == LLMProvider.AZURE_OPENAI:
+                self.provider_base_url = os.getenv("AZURE_OPENAI_ENDPOINT")
 
 
 # For backward compatibility


### PR DESCRIPTION
## Summary
- extend LLMProvider enum with `AZURE_OPENAI`
- add default model and env var in provider_config
- set Azure endpoint from env in LLM dataclass

## Testing
- `ruff check libs/python/agent/agent/core/types.py libs/python/agent/agent/core/provider_config.py`
- `mypy libs/python/agent/agent/core/types.py libs/python/agent/agent/core/provider_config.py` *(fails: Function is missing a type annotation)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688273f6897c832695e9dc0e79ca1244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Azure OpenAI provider, including automatic configuration of default models and environment variables.
  * Provider base URL for Azure OpenAI is now automatically set from the relevant environment variable if not provided.

* **Style**
  * Improved code formatting and import organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->