### PR TITLE
Add Azure OpenAI client support

### DIFF
--- a/libs/python/agent/agent/core/provider_config.py
+++ b/libs/python/agent/agent/core/provider_config.py
@@ -9,6 +9,7 @@ DEFAULT_MODELS = {
     LLMProvider.OLLAMA: "gemma3:4b-it-q4_K_M",
     LLMProvider.OAICOMPAT: "Qwen2.5-VL-7B-Instruct",
     LLMProvider.MLXVLM: "mlx-community/UI-TARS-1.5-7B-4bit",
+    LLMProvider.AZURE: "gpt-4o",
 }
 
 # Map providers to their environment variable names
@@ -18,4 +19,5 @@ ENV_VARS = {
     LLMProvider.OLLAMA: "none",
     LLMProvider.OAICOMPAT: "none",  # OpenAI-compatible API typically doesn't require an API key
     LLMProvider.MLXVLM: "none",  # MLX VLM typically doesn't require an API key
+    LLMProvider.AZURE: "AZURE_OPENAI_API_KEY",
 }

--- a/libs/python/agent/agent/core/types.py
+++ b/libs/python/agent/agent/core/types.py
@@ -24,6 +24,7 @@ class LLMProvider(StrEnum):
     OLLAMA = "ollama"
     OAICOMPAT = "oaicompat"
     MLXVLM= "mlxvlm"
+    AZURE = "azure"
 
 
 @dataclass

--- a/libs/python/agent/agent/providers/omni/clients/azure_openai.py
+++ b/libs/python/agent/agent/providers/omni/clients/azure_openai.py
@@ -1,0 +1,116 @@
+"""Azure OpenAI client implementation."""
+
+import os
+import logging
+from typing import Any, Dict, List, Optional
+import aiohttp
+import re
+from .base import BaseOmniClient
+
+logger = logging.getLogger(__name__)
+
+
+class AzureOpenAIClient(BaseOmniClient):
+    """Azure OpenAI API client implementation."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "gpt-4o",
+        provider_base_url: Optional[str] = None,
+        api_version: str = "2024-02-15-preview",
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ):
+        """Initialize the Azure OpenAI client.
+
+        Args:
+            api_key: Azure OpenAI API key
+            model: Deployment name to use
+            provider_base_url: Azure endpoint base URL (e.g. https://my-resource.openai.azure.com)
+            api_version: Azure OpenAI API version
+            max_tokens: Maximum tokens to generate
+            temperature: Generation temperature
+        """
+        super().__init__(api_key=api_key, model=model)
+        self.api_key = api_key or os.getenv("AZURE_OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("No Azure OpenAI API key provided")
+
+        if not provider_base_url:
+            provider_base_url = os.getenv("AZURE_OPENAI_ENDPOINT", "")
+        if not provider_base_url:
+            raise ValueError("Azure OpenAI endpoint must be provided")
+        self.provider_base_url = provider_base_url.rstrip("/")
+        self.api_version = api_version
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+    def _extract_base64_image(self, text: str) -> Optional[str]:
+        """Extract base64 image data from an HTML img tag."""
+        pattern = r'data:image/[^;]+;base64,([^"]+)'
+        match = re.search(pattern, text)
+        return match.group(1) if match else None
+
+    async def run_interleaved(
+        self, messages: List[Dict[str, Any]], system: str, max_tokens: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """Run interleaved chat completion."""
+        headers = {"Content-Type": "application/json", "api-key": self.api_key}
+
+        final_messages = [{"role": "system", "content": system}]
+        for item in messages:
+            if isinstance(item, dict):
+                if isinstance(item.get("content"), list):
+                    final_messages.append(item)
+                else:
+                    base64_img = self._extract_base64_image(item["content"])
+                    if base64_img:
+                        final_messages.append(
+                            {
+                                "role": item["role"],
+                                "content": [
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {"url": f"data:image/jpeg;base64,{base64_img}"},
+                                    }
+                                ],
+                            }
+                        )
+                    else:
+                        final_messages.append(
+                            {
+                                "role": item["role"],
+                                "content": [{"type": "text", "text": item["content"]}],
+                            }
+                        )
+            else:
+                base64_img = self._extract_base64_image(item)
+                if base64_img:
+                    final_messages.append(
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": f"data:image/jpeg;base64,{base64_img}"},
+                                }
+                            ],
+                        }
+                    )
+                else:
+                    final_messages.append({"role": "user", "content": [{"type": "text", "text": item}]})
+
+        payload = {"messages": final_messages, "temperature": self.temperature}
+        payload["max_tokens"] = max_tokens or self.max_tokens
+
+        endpoint_url = f"{self.provider_base_url}/openai/deployments/{self.model}/chat/completions?api-version={self.api_version}"
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(endpoint_url, headers=headers, json=payload) as response:
+                response_json = await response.json()
+                if response.status != 200:
+                    error_msg = response_json.get("error", {}).get("message", str(response_json))
+                    logger.error(f"Error in Azure OpenAI API call: {error_msg}")
+                    raise Exception(f"Azure OpenAI API error: {error_msg}")
+                return response_json

--- a/libs/python/agent/agent/providers/omni/loop.py
+++ b/libs/python/agent/agent/providers/omni/loop.py
@@ -18,6 +18,7 @@ from ...core.types import AgentResponse
 from computer import Computer
 from ...core.types import LLMProvider
 from .clients.openai import OpenAIClient
+from .clients.azure_openai import AzureOpenAIClient
 from .clients.anthropic import AnthropicClient
 from .clients.ollama import OllamaClient
 from .clients.oaicompat import OAICompatClient
@@ -139,6 +140,12 @@ class OmniLoop(BaseLoop):
                 api_key=self.api_key,
                 model=self.model,
             )
+        elif self.provider == LLMProvider.AZURE:
+            self.client = AzureOpenAIClient(
+                api_key=self.api_key,
+                model=self.model,
+                provider_base_url=self.provider_base_url,
+            )
         elif self.provider == LLMProvider.OLLAMA:
             self.client = OllamaClient(
                 api_key=self.api_key,
@@ -168,6 +175,12 @@ class OmniLoop(BaseLoop):
 
             if self.provider == LLMProvider.OPENAI:
                 self.client = OpenAIClient(api_key=self.api_key, model=self.model)
+            elif self.provider == LLMProvider.AZURE:
+                self.client = AzureOpenAIClient(
+                    api_key=self.api_key,
+                    model=self.model,
+                    provider_base_url=self.provider_base_url,
+                )
             elif self.provider == LLMProvider.ANTHROPIC:
                 self.client = AnthropicClient(
                     api_key=self.api_key,
@@ -266,6 +279,21 @@ class OmniLoop(BaseLoop):
                     response = await self.client.run_interleaved(
                         messages=filtered_messages,
                         system=final_system_prompt,
+                        max_tokens=self.max_tokens,
+                    )
+                elif self.provider == LLMProvider.AZURE:
+                    # Azure uses OpenAI-compatible format
+                    request_data = {
+                        "messages": prepared_messages,
+                        "max_tokens": self.max_tokens,
+                        "system": system_prompt,
+                    }
+
+                    self._log_api_call("request", request_data)
+
+                    response = await self.client.run_interleaved(
+                        messages=prepared_messages,
+                        system=system_prompt,
                         max_tokens=self.max_tokens,
                     )
                 else:
@@ -406,6 +434,13 @@ class OmniLoop(BaseLoop):
             elif self.provider == LLMProvider.OAICOMPAT:
                 try:
                     # OpenAI-compatible response format
+                    raw_text = response["choices"][0]["message"]["content"]
+                    standard_content = [{"type": "text", "text": raw_text}]
+                except (KeyError, TypeError, IndexError) as e:
+                    logger.error(f"Invalid response format: {str(e)}")
+                    return True, action_screenshot_saved
+            elif self.provider == LLMProvider.AZURE:
+                try:
                     raw_text = response["choices"][0]["message"]["content"]
                     standard_content = [{"type": "text", "text": raw_text}]
                 except (KeyError, TypeError, IndexError) as e:


### PR DESCRIPTION
## Summary
- add `AZURE` to `LLMProvider` and update default configs
- implement `AzureOpenAIClient`
- instantiate `AzureOpenAIClient` in Omni loop initialization
- extend runtime conditionals to handle Azure requests and responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882740311248326a75283120e701d8e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure OpenAI as a provider, enabling use of Azure-hosted language models.
  * Users can now interact with Azure OpenAI models, including handling of interleaved text and base64-encoded images in chat messages.

* **Bug Fixes**
  * Improved response handling for Azure OpenAI to ensure consistent message formatting with other providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->