### PR TITLE
Add AzureOpenAIClient with tests

### DIFF
--- a/libs/python/agent/agent/providers/omni/clients/azure.py
+++ b/libs/python/agent/agent/providers/omni/clients/azure.py
@@ -1,0 +1,118 @@
+"""Azure OpenAI client implementation."""
+
+import os
+import logging
+from typing import Dict, List, Optional, Any
+import aiohttp
+import re
+
+from .base import BaseOmniClient
+
+logger = logging.getLogger(__name__)
+
+
+class AzureOpenAIClient(BaseOmniClient):
+    """Azure OpenAI API client implementation."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "gpt-4o",
+        provider_base_url: Optional[str] = None,
+        deployment_name: Optional[str] = None,
+        api_version: str = "2024-05-01-preview",
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+    ) -> None:
+        super().__init__(api_key=api_key, model=model)
+        self.api_key = api_key or os.getenv("AZURE_OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("No Azure OpenAI API key provided")
+
+        self.model = model
+        self.provider_base_url = (provider_base_url or "").rstrip("/")
+        self.deployment_name = deployment_name or model
+        self.api_version = api_version
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+    def _extract_base64_image(self, text: str) -> Optional[str]:
+        pattern = r'data:image/[^;]+;base64,([^\"]+)'
+        match = re.search(pattern, text)
+        return match.group(1) if match else None
+
+    async def run_interleaved(
+        self, messages: List[Dict[str, Any]], system: str, max_tokens: Optional[int] = None
+    ) -> Dict[str, Any]:
+        headers = {
+            "Content-Type": "application/json",
+            "api-key": self.api_key,
+        }
+
+        final_messages = [{"role": "system", "content": system}]
+
+        for item in messages:
+            if isinstance(item, dict):
+                if isinstance(item.get("content"), list):
+                    final_messages.append(item)
+                else:
+                    base64_img = self._extract_base64_image(item["content"])
+                    if base64_img:
+                        message = {
+                            "role": item["role"],
+                            "content": [
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": f"data:image/jpeg;base64,{base64_img}"},
+                                }
+                            ],
+                        }
+                    else:
+                        message = {
+                            "role": item["role"],
+                            "content": [{"type": "text", "text": item["content"]}],
+                        }
+                    final_messages.append(message)
+            else:
+                base64_img = self._extract_base64_image(item)
+                if base64_img:
+                    message = {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": f"data:image/jpeg;base64,{base64_img}"},
+                            }
+                        ],
+                    }
+                else:
+                    message = {"role": "user", "content": [{"type": "text", "text": item}]}
+                final_messages.append(message)
+
+        payload = {"model": self.model, "messages": final_messages, "temperature": self.temperature}
+
+        if "o1" in self.model or "o3-mini" in self.model:
+            payload["reasoning_effort"] = "low"
+            payload["max_completion_tokens"] = max_tokens or self.max_tokens
+        else:
+            payload["max_tokens"] = max_tokens or self.max_tokens
+
+        endpoint = (
+            f"{self.provider_base_url}/openai/deployments/{self.deployment_name}/chat/completions"
+            f"?api-version={self.api_version}"
+        )
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(endpoint, headers=headers, json=payload) as response:
+                    response_json = await response.json()
+
+                    if response.status != 200:
+                        error_msg = response_json.get("error", {}).get("message", str(response_json))
+                        logger.error(f"Error in Azure OpenAI API call: {error_msg}")
+                        raise Exception(f"Azure OpenAI API error: {error_msg}")
+
+                    return response_json
+        except Exception as e:
+            logger.error(f"Error in Azure OpenAI API call: {str(e)}")
+            raise

--- a/tests/test_azure_openai_client.py
+++ b/tests/test_azure_openai_client.py
@@ -1,0 +1,115 @@
+import sys
+from pathlib import Path
+import importlib.util
+import types
+import pytest
+
+# Import AzureOpenAIClient directly from its file to avoid heavy package imports
+project_root = Path(__file__).resolve().parents[1]
+clients_dir = project_root / "libs/python/agent/agent/providers/omni/clients"
+azure_path = clients_dir / "azure.py"
+base_path = clients_dir / "base.py"
+
+# Create stub packages so relative imports work without executing package __init__ files
+pkg_names = [
+    "agent",
+    "agent.providers",
+    "agent.providers.omni",
+    "agent.providers.omni.clients",
+]
+for name in pkg_names:
+    if name not in sys.modules:
+        module = types.ModuleType(name)
+        module.__path__ = [str(clients_dir)] if name.endswith("clients") else []
+        sys.modules[name] = module
+
+spec_base = importlib.util.spec_from_file_location(
+    "agent.providers.omni.clients.base", base_path
+)
+base_module = importlib.util.module_from_spec(spec_base)
+sys.modules[spec_base.name] = base_module
+spec_base.loader.exec_module(base_module)  # type: ignore
+
+spec = importlib.util.spec_from_file_location(
+    "agent.providers.omni.clients.azure", azure_path
+)
+azure_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = azure_module
+spec.loader.exec_module(azure_module)  # type: ignore
+
+AzureOpenAIClient = azure_module.AzureOpenAIClient
+
+
+class DummyResponse:
+    def __init__(self, status: int, json_data):
+        self.status = status
+        self._json = json_data
+
+    async def json(self):
+        return self._json
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummySession:
+    def __init__(self, response):
+        self.response = response
+        self.url = None
+        self.headers = None
+        self.payload = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def post(self, url, headers=None, json=None):
+        self.url = url
+        self.headers = headers
+        self.payload = json
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_run_interleaved_posts_to_azure(monkeypatch):
+    expected = {"id": "1", "choices": [{"message": {"content": "hi"}}]}
+    session = DummySession(DummyResponse(200, expected))
+    monkeypatch.setattr("aiohttp.ClientSession", lambda: session)
+
+    client = AzureOpenAIClient(
+        api_key="key",
+        provider_base_url="https://example.openai.azure.com",
+        deployment_name="test-deploy",
+        api_version="2024-05-01-preview",
+    )
+
+    messages = [{"role": "user", "content": "Hello"}]
+    result = await client.run_interleaved(messages, "You are a bot")
+
+    assert session.url == (
+        "https://example.openai.azure.com/openai/deployments/test-deploy/chat/completions"
+        "?api-version=2024-05-01-preview"
+    )
+    assert result == expected
+    assert session.payload["messages"][0]["role"] == "system"
+
+
+@pytest.mark.asyncio
+async def test_run_interleaved_error(monkeypatch):
+    session = DummySession(DummyResponse(400, {"error": {"message": "bad"}}))
+    monkeypatch.setattr("aiohttp.ClientSession", lambda: session)
+
+    client = AzureOpenAIClient(
+        api_key="key",
+        provider_base_url="https://example.openai.azure.com",
+        deployment_name="test-deploy",
+    )
+
+    with pytest.raises(Exception, match="Azure OpenAI API error: bad"):
+        await client.run_interleaved([{"role": "user", "content": "hi"}], "sys")
+


### PR DESCRIPTION
## Summary
- add `AzureOpenAIClient` implementation for Azure chat completions
- add tests verifying requests sent to Azure endpoint

## Testing
- `pytest tests/test_azure_openai_client.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_688274138e8483268cc3ca9359ff2e35